### PR TITLE
fix: coerce uiAmount if number

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -285,7 +285,7 @@ declare module '@solana/web3.js' {
   };
 
   export type TokenAmount = {
-    uiAmount: number;
+    uiAmount: string;
     decimals: number;
     amount: string;
   };
@@ -294,7 +294,7 @@ declare module '@solana/web3.js' {
     address: PublicKey;
     amount: string;
     decimals: number;
-    uiAmount: number;
+    uiAmount: string;
   };
 
   export type AccountChangeCallback = (

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -298,7 +298,7 @@ declare module '@solana/web3.js' {
   };
 
   declare export type TokenAmount = {
-    uiAmount: number,
+    uiAmount: string,
     decimals: number,
     amount: string,
   };
@@ -307,7 +307,7 @@ declare module '@solana/web3.js' {
     address: PublicKey,
     amount: string,
     decimals: number,
-    uiAmount: number,
+    uiAmount: string,
   };
 
   declare type AccountChangeCallback = (

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -750,12 +750,12 @@ const GetSupplyRpcResult = jsonRpcResultAndContext(
  * @typedef {Object} TokenAmount
  * @property {string} amount Raw amount of tokens as string ignoring decimals
  * @property {number} decimals Number of decimals configured for token's mint
- * @property {number} uiAmount Token account as float, accounts for decimals
+ * @property {string} uiAmount Token account as float, accounts for decimals
  */
 type TokenAmount = {
   amount: string,
   decimals: number,
-  uiAmount: number,
+  uiAmount: string,
 };
 
 /**
@@ -763,7 +763,7 @@ type TokenAmount = {
  */
 const TokenAmountResult = pick({
   amount: string(),
-  uiAmount: number(),
+  uiAmount: coerce(string(), number(), value => value.toString()),
   decimals: number(),
 });
 
@@ -774,13 +774,13 @@ const TokenAmountResult = pick({
  * @property {PublicKey} address Address of the token account
  * @property {string} amount Raw amount of tokens as string ignoring decimals
  * @property {number} decimals Number of decimals configured for token's mint
- * @property {number} uiAmount Token account as float, accounts for decimals
+ * @property {string} uiAmount Token account as float, accounts for decimals
  */
 type TokenAccountBalancePair = {
   address: PublicKey,
   amount: string,
   decimals: number,
-  uiAmount: number,
+  uiAmount: string,
 };
 
 /**
@@ -791,7 +791,7 @@ const GetTokenLargestAccountsResult = jsonRpcResultAndContext(
     pick({
       address: PublicKeyFromString,
       amount: string(),
-      uiAmount: number(),
+      uiAmount: coerce(string(), number(), value => value.toString()),
       decimals: number(),
     }),
   ),

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1209,7 +1209,7 @@ describe('Connection', () => {
       it('get token supply', async () => {
         const supply = (await connection.getTokenSupply(testToken.publicKey))
           .value;
-        expect(supply.uiAmount).to.eq(111.11);
+        expect(supply.uiAmount).to.eq('111.11');
         expect(supply.decimals).to.eq(2);
         expect(supply.amount).to.eq('11111');
 
@@ -1226,7 +1226,7 @@ describe('Connection', () => {
         expect(largestAccount.address).to.eql(testTokenAccount);
         expect(largestAccount.amount).to.eq('11110');
         expect(largestAccount.decimals).to.eq(2);
-        expect(largestAccount.uiAmount).to.eq(111.1);
+        expect(largestAccount.uiAmount).to.eq('111.1');
 
         await expect(connection.getTokenLargestAccounts(newAccount)).to.be
           .rejected;
@@ -1265,7 +1265,7 @@ describe('Connection', () => {
         ).value;
         expect(balance.amount).to.eq('11110');
         expect(balance.decimals).to.eq(2);
-        expect(balance.uiAmount).to.eq(111.1);
+        expect(balance.uiAmount).to.eq('111.1');
 
         await expect(connection.getTokenAccountBalance(newAccount)).to.be
           .rejected;


### PR DESCRIPTION
I'll want to double-check this is sufficient when the rest of the test suite passes, but all green against both solana edge and solana v1.5.8 for:
      ✓ get token supply
      ✓ get token largest accounts
      ✓ get token account balance
      ✓ get parsed token account info
      ✓ get parsed token program accounts