### PR TITLE
DCOU-ify the collector id for tests parameter

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1078,7 +1078,7 @@ impl Bank {
         debug_do_not_add_builtins: bool,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
-        #[cfg(feature = "dev-context-only-utils")] test_collector_id: Option<Pubkey>,
+        #[cfg(feature = "dev-context-only-utils")] collector_id_for_tests: Option<Pubkey>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts_db = AccountsDb::new_with_config(
@@ -1100,7 +1100,7 @@ impl Bank {
         #[cfg(not(feature = "dev-context-only-utils"))]
         bank.process_genesis_config(genesis_config);
         #[cfg(feature = "dev-context-only-utils")]
-        bank.process_genesis_config(genesis_config, test_collector_id);
+        bank.process_genesis_config(genesis_config, collector_id_for_tests);
 
         bank.finish_init(
             genesis_config,
@@ -3794,7 +3794,7 @@ impl Bank {
     fn process_genesis_config(
         &mut self,
         genesis_config: &GenesisConfig,
-        #[cfg(feature = "dev-context-only-utils")] test_collector_id: Option<Pubkey>,
+        #[cfg(feature = "dev-context-only-utils")] collector_id_for_tests: Option<Pubkey>,
     ) {
         // Bootstrap validator collects fees until `new_from_parent` is called.
         self.fee_rate_governor = genesis_config.fee_rate_governor.clone();
@@ -3827,7 +3827,7 @@ impl Bank {
         // collector id during tests.
         let collector_id = self.stakes_cache.stakes().highest_staked_node();
         #[cfg(feature = "dev-context-only-utils")]
-        let collector_id = collector_id.or(test_collector_id);
+        let collector_id = collector_id.or(collector_id_for_tests);
         self.collector_id =
             collector_id.expect("genesis processing failed because no staked nodes exist");
 


### PR DESCRIPTION
* Put the tests-only collector id behind a DCOU feature
* Rename the param to `collector_id_for_tests`
