### PR TITLE
Fix unused variable warning for `leader_for_tests` in Bank::new_from_snapshot

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1872,6 +1872,7 @@ impl Bank {
         let leader: SlotLeader;
         #[cfg(not(feature = "dev-context-only-utils"))]
         {
+            _ = leader_for_tests;
             leader = Self::slot_leader_from_epoch_stakes(
                 fields.slot,
                 &fields.epoch_schedule,


### PR DESCRIPTION
The `leader_for_tests` parameter is only used inside the
`#[cfg(feature = "dev-context-only-utils")]` block, causing an unused
variable warning in normal builds. Explicitly discard it with `_ =` in
the `#[cfg(not(feature = "dev-context-only-utils"))]` block.

https://claude.ai/code/session_019ZWhcr7DdEnj3hLTxd7xU6